### PR TITLE
refactor: Proposing method' renaming

### DIFF
--- a/src/Veins/Template/Plugin/Compress.php
+++ b/src/Veins/Template/Plugin/Compress.php
@@ -55,10 +55,10 @@ class Compress extends \Leaf\Veins\Template\Plugin {
 
         $html = $context->code;
         if( $this->conf['css']['status'] )
-            $html = $this->compressCSS( $html );
+            $html = $this->compressStyle( $html );
 
         if( $this->conf['javascript']['status'] )
-            $html = self::compressJavascript( $html );
+            $html = self::compressScript( $html );
 
         if( $this->conf['html']['status'] )
             $html = $this->compressHTML($html);
@@ -109,7 +109,7 @@ class Compress extends \Leaf\Veins\Template\Plugin {
      * @param type $html
      * @return type 
      */
-    protected function compressCSS($html) {
+    protected function compressStyle($html) {
 
         // search for all stylesheet
         if (!preg_match_all("/<link.*href=\"(.*?\.css)\".*>/", $html, $matches))
@@ -194,7 +194,7 @@ class Compress extends \Leaf\Veins\Template\Plugin {
      * @param type $html
      * @return type 
      */
-    protected function compressJavascript($html) {
+    protected function compressScript($html) {
 
         $htmlToCheck = preg_replace("<!--.*?-->", "", $html);
 

--- a/src/core/Http/response.php
+++ b/src/core/Http/response.php
@@ -28,7 +28,7 @@
         //     echo $res;
         // }
 
-        public function renderHtmlPage($file) {
+        public function renderHtml($file) {
             header('Content-Type: text/html');
             require $file;
         }


### PR DESCRIPTION
Hello,

My purpose is rename some methods to be more intuitive and clear for users, like `CSS` are our `Style` and `Javascript` are `Scripts`.

| old name           | new name       | file name                               |
| ------------------ | -------------- | --------------------------------------- |
| compressJavascript | compressScript | /src/Veins/Template/Plugin/Compress.php |
| compressCSS        | compressStyle  | /src/Veins/Template/Plugin/Compress.php |
| renderHtmlPage     | renderHtml     | /src/core/Http/response.php             |

I know these changes affect the [site documentation](https://leaf-docs.netlify.com/). I will be available to update this if the pull-request is accepted.